### PR TITLE
Voting polling improvements

### DIFF
--- a/app/api/vote/manage/route.ts
+++ b/app/api/vote/manage/route.ts
@@ -287,7 +287,7 @@ export async function GET(req: Request) {
         endTime: vote.endTime?.toISOString() || null,
         boardResults,
         blackballResults,
-        totalVotes: validVotes.filter((v: any) => v.round === "board").length,
+        totalVotes: new Set(validVotes.filter((v: any) => v.round === "board").map((v: any) => v.clerkId)).size, // Count unique voters
         voterListVerified: vote.voterListVerified || false,
       });
     }


### PR DESCRIPTION
 - Optimized polling behavior to reduce Netlify API requests during active voting sessions (tryna stay on the free plan fr)
 - Security improvements, uses atomic updates when registering votes received to prevent people from exploiting a race condition to vote twice
 - Various spaghetti code to ensure the voting experience is seamless as possible while not hammering the API
 - Website no longer contacts the API when the tab isn't focused
 - Voting has completed alert is now bootstrap-primary
 - Added "voted" badge in votes list
 - Removed "xyz ballots" in the votes list (you can still get the info by clicking on the vote, this was redundant)
 - Some other stuff I definitely forgot about